### PR TITLE
Add InfluxDB app

### DIFF
--- a/apps/dev-efd/templates/influxdb.yaml
+++ b/apps/dev-efd/templates/influxdb.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: influxdb
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: influxdb
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: influxdb
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: apps/influxdb
+    repoURL: https://github.com/lsst-sqre/argocd-efd
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true

--- a/apps/influxdb/Chart.yaml
+++ b/apps/influxdb/Chart.yaml
@@ -1,0 +1,1 @@
+name: influxdb

--- a/apps/influxdb/requirements.yaml
+++ b/apps/influxdb/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: influxdb
+  version: 3.0.2
+  repository: https://kubernetes-charts.storage.googleapis.com/ 

--- a/apps/influxdb/values-gke.yaml
+++ b/apps/influxdb/values-gke.yaml
@@ -1,0 +1,106 @@
+---
+influxdb:
+  ## influxdb image version
+  ## ref: https://hub.docker.com/r/library/influxdb/tags/
+  image:
+    repo: "influxdb"
+    tag: "1.7.6-alpine"
+    pullPolicy: IfNotPresent
+
+  ## Specify a service type
+  ## NodePort is default
+  ## ref: http://kubernetes.io/docs/user-guide/services/
+  ##
+  service:
+    ## Add annotations to service
+    # annotations: {}
+    type: ClusterIP
+    ## Add IP Cluster
+    # clusterIP: ""
+    ## Add external IPs that route to one or more cluster nodes
+    # externalIPs: []
+    ## Specify LoadBalancer IP (only allow on some cloud provider)
+    # loadBalancerIP: ""
+    ## Allow source IPs to access on service (if empty, any access allow)
+    # loadBalancerSourceRanges: []
+
+  ## Persist data to a persistent volume
+  ##
+  persistence:
+    enabled: true
+    ## If true will use an existing PVC instead of creating one
+    # useExisting: false
+    ## Name of existing PVC to be used in the influx deployment
+    # name:
+    ## influxdb data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 15Gi
+
+  ## Create default user through Kubernetes job
+  ## Defaults indicated below
+  ##
+  setDefaultUser:
+    enabled: true
+
+    ## Image of the container used for job
+    ## Default: appropriate/curl:latest
+    ##
+    image: appropriate/curl:latest
+
+    ## Deadline for job so it does not retry forever.
+    ## Default: activeDeadline: 300
+    ##
+    activeDeadline: 300
+
+    ## Restart policy for job
+    ## Default: OnFailure
+    restartPolicy: OnFailure
+
+    user:
+
+      ## The user name
+      ## Default: "admin"
+      username: "admin"
+
+      ## User password
+      ## single quotes must be escaped (\')
+      ## Default: (Randomly generated 10 characters of AlphaNum)
+      # password:
+
+      ## User privileges
+      ## Default: "WITH ALL PRIVILEGES"
+      privileges: "WITH ALL PRIVILEGES"
+
+  ingress:
+    enabled: false 
+    tls: true
+    secretName: tls-certs
+    hostname: influxdb-gke-efd.lsst.codes
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/affinity: "cookie"
+      nginx.ingress.kubernetes.io/proxy-body-size: "0m"
+      nginx.ingress.kubernetes.io/rewrite-target: /
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Port 443;
+        proxy_set_header X-Forwarded-Path /;
+
+  ## Change InfluxDB configuration parameters below:
+  ## ref: https://docs.influxdata.com/influxdb/v1.7/administration/config/
+  config:
+    http:
+      enabled: true
+      auth_enabled: true
+      max_row_limit: 0
+  
+  backup:
+    enabled: false


### PR DESCRIPTION
Adds InfluxDB app bootstrapped by the `dev-efd` parent app. Note that the ingress configuration is still missing.