### PR TITLE
DM-26737 Troubleshooting Zookeeper on the Base EFD cluster

### DIFF
--- a/apps/cp-helm-charts/values-base.yaml
+++ b/apps/cp-helm-charts/values-base.yaml
@@ -34,6 +34,9 @@ cp-helm-charts:
     #  requests:
     #   cpu: 100m
     #   memory: 128Mi
+    # Used to regulate heartbeats, and timeouts. For example, the minimum session timeout will be two ticks.
+    configurationOverrides:
+      tickTime: 8000
 
   ## ------------------------------------------------------
   ## Kafka


### PR DESCRIPTION

Increase Zookeeper session timeout. Set Zookeeper `tickTime` to 8000ms, it is used to regulate heartbeats, and timeouts. For example, the minimum session timeout will be two ticks.